### PR TITLE
Add support for dismissing notifications

### DIFF
--- a/source/INotificationService.cs
+++ b/source/INotificationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using Microsoft.JSInterop;
+using System.Threading.Tasks;
 
 namespace Append.Blazor.Notifications
 {
@@ -26,15 +27,15 @@ namespace Append.Blazor.Notifications
         /// </summary>
         /// <param name="title"></param>
         /// <param name="options"></param>
-        /// <returns></returns>
-        ValueTask CreateAsync(string title, NotificationOptions options);
+        /// <returns>The created <see cref="Notification"/>.</returns>
+        ValueTask<Notification> CreateAsync(string title, NotificationOptions options);
         /// <summary>
         /// Creates a Notifcation with the supplied parameters.
         /// </summary>
         /// <param name="title">The title of the notification.</param>
         /// <param name="description">The body or description of the notification.</param>
         /// <param name="iconUrl">Link to a image, can be remote or served from the filesystem.</param>
-        /// <returns></returns>
-        ValueTask CreateAsync(string title, string description, string iconUrl = null);
+        /// <returns>The created <see cref="Notification"/>.</returns>
+        ValueTask<Notification> CreateAsync(string title, string description, string iconUrl = null);
     }
 }

--- a/source/NotificationService.cs
+++ b/source/NotificationService.cs
@@ -37,14 +37,15 @@ namespace Append.Blazor.Notifications
         }
 
         /// <inheritdoc/>
-        public async ValueTask CreateAsync(string title, NotificationOptions options)
+        public async ValueTask<Notification> CreateAsync(string title, NotificationOptions options)
         {
             var module = await _moduleTask.Value;
-            await module.InvokeVoidAsync("create", title, options);
+            var jsObject = await module.InvokeAsync<IJSObjectReference>("create", title, options);
+            return new Notification(title, jsObject, options);
         }
 
         /// <inheritdoc/>
-        public async ValueTask CreateAsync(string title, string body, string icon = null)
+        public async ValueTask<Notification> CreateAsync(string title, string body, string icon = null)
         {
             var module = await _moduleTask.Value;
 
@@ -54,7 +55,8 @@ namespace Append.Blazor.Notifications
                 Icon = icon,
             };
 
-            await module.InvokeVoidAsync("create", title, options);
+            var jsObject = await module.InvokeAsync<IJSObjectReference>("create", title, options);
+            return new Notification(title, jsObject, options);
         }
 
         public async ValueTask DisposeAsync()


### PR DESCRIPTION
Adding ability to dismiss a notification if it expires or for other reason.

One thing I noticed is that the "Timeout" option doesn't actually appear to do anything (and couldn't find any [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification) that indicated such a parameter exists), so I needed a way to actually dismiss a notification when it expired.

This is potentially a breaking change because it changes the return type of the CreateAsync methods. I re-used the Notification class that seemed to be unused as the return type (since it mostly had some useful data on it already) and added a Close method to pass to the javascript method with the same name.

Only part I wish was a bit cleaner is that the Notification has to be disposable, due to IJSObjectReference itself being disposable. Possibly there _should_ be two ways to call it, one if you want the notification back and one if you don't.